### PR TITLE
Technical Documentation: Added Chinese ('Apache_test_ch_tx') and English ('Apache_test_en_tx') Versions

### DIFF
--- a/docs/Apache_test_en_tx.md
+++ b/docs/Apache_test_en_tx.md
@@ -1,0 +1,27 @@
+Apache Cloudberry-pg_controldata
+=======
+pg_controldata — displays the control information of a PostgreSQL database cluster.
+
+Synopsis
+-------------
+`pg_controldata` [_`option`_] [[ `-D` | `--pgdata` ]_`datadir`_]
+
+Description
+-------------
+`pg_controldata` prints information initialized during `initdb`, such as the catalog version. It also shows information about write-ahead logging and checkpoint processing. This information is cluster-wide, and not specific to any one database.
+
+This utility can only be run by the user who initialized the cluster because it requires read access to the data directory. You can specify the data directory on the command line, or use the environment variable `PGDATA`. This utility supports the options `-V` and `--version`, which print the pg_controldata version and exit. It also supports options `-?` and `--help`, which output the supported arguments.
+
+Environment
+-------------
+`PGDATA`
+
+Default data directory location.
+
+`PG_COLOR`
+
+Specifies whether to use color in diagnostic messages. Possible values are `always`, `auto` and `never`.
+
+Submit correction
+------------
+If you see anything in the documentation that is not correct, does not match your experience with the particular feature or requires further clarification, please use [this form](https://www.postgresql.org/account/comments/new/14/app-pgcontroldata.html/) to report a documentation issue.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/Apache_test_ch_tx.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/Apache_test_ch_tx.md
@@ -1,0 +1,28 @@
+Apache Cloudberry-pg_controldata
+=======
+pg_controldata — 显示PostgreSQL数据库集群的控制信息。
+
+概要
+-------------
+`pg_controldata` [_`option`_] [[ `-D` | `--pgdata` ]_`datadir`_]
+
+描述
+-------------
+`pg_controldata` 打印在 `initdb` 期间初始化的信息，例如目录版本。它还显示有关预写日志记录和检查点处理的信息。这些信息是集群范围的，而不是特定于任何单个数据库的。
+
+此工具只能由初始化集群的用户运行，因为它需要对数据目录的读取访问权限。您可以在命令行上指定数据目录，或者使用环境变量 `PGDATA`。此工具支持选项 `-V` 和 `--version`，它们会打印 `pg_controldata` 的版本并退出。它还支持选项 `-?` 和 `--help`，它们会输出受支持的参数。
+
+环境
+-------------
+
+`PGDATA`
+
+默认数据目录位置。
+
+`PG_COLOR`
+
+指定是否在诊断消息中使用颜色。可能的值为`always`、`auto`和`never`。
+
+提交更正
+------------
+如果您发现文档中存在任何不正确的内容、与您对特定功能的体验不符或需要进一步说明，请使用 [此表格](https://www.postgresql.org/account/comments/new/14/app-pgcontroldata.html/) 报告文档问题。


### PR DESCRIPTION
This PR adds the Apache English documentation to /docs and the Apache Chinese documentation to /i18n/zh/docusaurus-plugin-content-docs/current.

- The English documentation is structured under /docs
- The Chinese documentation is structured under /i18n/zh/docusaurus-plugin-content-docs/current

---

## Change logs

> Describe your change clearly, including what problem is being solved or what document is being added or updated.

## Contributor's checklist

Here are some reminders before you submit your pull request:

* Make sure that your Pull Request has a clear title and commit message. You can take the [Git commit template](https://github.com/apache/cloudberry/blob/main/.gitmessage) as a reference.
* Learn the [code contribution](https://cloudberry.apache.org/contribute/code) and [doc contribution](https://cloudberry.apache.org/contribute/doc) guides for better collaboration.
* Make sure that your changes deployment preview is successful.
* List your communications in the [GitHub Issues](https://github.com/apache/cloudberry-site/issues) or [Discussions](https://github.com/apache/cloudberry/discussions) (if has or needed).
* Feel free to ask for the [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers) or other people to help review and approve.
