### PR TITLE
Add Step to "Install from Source" on Rocky Linux

### DIFF
--- a/docs/cbdb-linux-compile.md
+++ b/docs/cbdb-linux-compile.md
@@ -216,6 +216,7 @@ After you have installed all the dependencies and performed the prerequisite pla
     <TabItem value="ubuntu-rocky-rhel" label="For Ubuntu, Rocky Linux, and RHEL" default>
 
     ```bash
+    source /usr/local/cloudberry/greenplum_path.sh
     make create-demo-cluster
     ```
 


### PR DESCRIPTION
When following the documentation, I had to source the greenplum_path.sh before I was able to run the create-demo-cluster step.

<!--Thank you for contributing! -->
---

## Change logs
While installing Cloudberry from source (on Rocky 9) I had to perform 1 more step to get the example working. To note, other than this step the instructions for Rocky 8 and RHEL 8 work with Rocky 9 and perhaps the tab names should be updated as well.

## Contributor's checklist

Here are some reminders before you submit your pull request:

* Make sure that your Pull Request has a clear title and commit message. You can take the [Git commit template](https://github.com/apache/cloudberry/blob/main/.gitmessage) as a reference.
* Learn the [code contribution](https://cloudberry.apache.org/contribute/code) and [doc contribution](https://cloudberry.apache.org/contribute/doc) guides for better collaboration.
* Make sure that your changes deployment preview is successful.
* List your communications in the [GitHub Issues](https://github.com/apache/cloudberry-site/issues) or [Discussions](https://github.com/apache/cloudberry/discussions) (if has or needed).
* Feel free to ask for the [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers) or other people to help review and approve.
