### PR TITLE
Fix broken FAQ link to Cloudberry vs Greenplum docs

### DIFF
--- a/src/consts/homeContent.tsx
+++ b/src/consts/homeContent.tsx
@@ -118,7 +118,7 @@ let FREQUENTLY_ASKED_QUESTIONS = {
           Though Apache Cloudberry (Incubating) takes the Greenplum Database 7 as its codebase, Cloudberry has a newer solid PostgreSQL kernel built-in and has more features. You can check the 
           <LinkWithBaseUrl
             className="active-color"
-            href="https://cloudberry.apache.org/docs/cbdb-vs-gp-features"
+            href="https://cloudberry.apache.org/docs/introduction/cbdb-vs-gp-features/"
           >
             {" "}
             docs{" "}


### PR DESCRIPTION
## What changed

Updated the homepage FAQ link for the Cloudberry vs Greenplum comparison page to point to the existing docs page under `/docs/introduction/cbdb-vs-gp-features/`.

## Why

The current FAQ link points to `https://cloudberry.apache.org/docs/cbdb-vs-gp-features`, which returns 404. The docs page exists at `https://cloudberry.apache.org/docs/introduction/cbdb-vs-gp-features/`.

Fixes #371.

## Verification

- `curl -I -L https://cloudberry.apache.org/docs/cbdb-vs-gp-features` returns 404
- `curl -I -L https://cloudberry.apache.org/docs/introduction/cbdb-vs-gp-features/` returns 200
- GitHub compare shows one file changed: `src/consts/homeContent.tsx` (`+1 -1`)
