### PR TITLE
Add PostgreSQL Base column to Releases table

### DIFF
--- a/src/pages/releases/index.md
+++ b/src/pages/releases/index.md
@@ -16,6 +16,7 @@ Convenience binaries for Cloudberry have been available since version 2.1.0. You
 <tr>
 <th>Version</th>
 <th>Date</th>
+<th>PostgreSQL Base</th>
 <th>Source archive</th>
 <th>Signature & Checksum</th>
 <th>Convenience Binaries</th>
@@ -26,6 +27,7 @@ Convenience binaries for Cloudberry have been available since version 2.1.0. You
 <tr>
 <td rowSpan="3">2.1.0-incubating <strong>(Latest)</strong></td>
 <td rowSpan="3">April 14, 2026</td>
+<td rowSpan="3">PostgreSQL 14.4</td>
 <td><a href="https://www.apache.org/dyn/closer.lua/incubator/cloudberry/2.1.0-incubating/apache-cloudberry-2.1.0-incubating-src.tar.gz?action=download">apache-cloudberry-2.1.0-incubating-src.tar.gz</a></td>
 <td><a href="https://downloads.apache.org/incubator/cloudberry/2.1.0-incubating/apache-cloudberry-2.1.0-incubating-src.tar.gz.asc">.asc</a>, <a href="https://downloads.apache.org/incubator/cloudberry/2.1.0-incubating/apache-cloudberry-2.1.0-incubating-src.tar.gz.sha512">.sha512</a></td>
 <td><a href="https://github.com/apache/cloudberry/releases/tag/2.1.0-incubating">RPM/DEB</a></td>
@@ -44,6 +46,7 @@ Convenience binaries for Cloudberry have been available since version 2.1.0. You
 <tr>
 <td>2.0.0-incubating</td>
 <td>August 25, 2025</td>
+<td>PostgreSQL 14.4</td>
 <td><a href="https://archive.apache.org/dist/incubator/cloudberry/2.0.0-incubating/apache-cloudberry-2.0.0-incubating-src.tar.gz">apache-cloudberry-2.0.0-incubating-src.tar.gz</a></td>
 <td><a href="https://downloads.apache.org/incubator/cloudberry/2.0.0-incubating/apache-cloudberry-2.0.0-incubating-src.tar.gz.asc">.asc</a>, <a href="https://downloads.apache.org/incubator/cloudberry/2.0.0-incubating/apache-cloudberry-2.0.0-incubating-src.tar.gz.sha512">.sha512</a></td>
 <td>-</td>


### PR DESCRIPTION
Add a "PostgreSQL Base" column after Date in the Releases download table. Both 2.0.0-incubating and 2.1.0-incubating are based on PostgreSQL 14.4.

<!--Thank you for contributing! -->

<!--In case of an existing issue or discussions, please reference it-->
closes: #376 
<!--Remove this section if no corresponding issue.-->

---

## Change logs

> Describe your change clearly, including what problem is being solved or what document is being added or updated.

## Contributor's checklist

Here are some reminders before you submit your pull request:

* Make sure that your Pull Request has a clear title and commit message. You can take the [Git commit template](https://github.com/apache/cloudberry/blob/main/.gitmessage) as a reference.
* Learn the [code contribution](https://cloudberry.apache.org/contribute/code) and [doc contribution](https://cloudberry.apache.org/contribute/doc) guides for better collaboration.
* Make sure that your changes deployment preview is successful.
* List your communications in the [GitHub Issues](https://github.com/apache/cloudberry-site/issues) or [Discussions](https://github.com/apache/cloudberry/discussions) (if has or needed).
* Feel free to ask for the [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers) or other people to help review and approve.
