### PR TITLE
Fix: make blog display the correct blog date

### DIFF
--- a/src/theme/BlogPostItem/components/Authors/index.tsx
+++ b/src/theme/BlogPostItem/components/Authors/index.tsx
@@ -1,12 +1,19 @@
 import { useBlogPost } from "@docusaurus/plugin-content-blog/client";
+import { useDateTimeFormat } from "@docusaurus/theme-common/internal";
 export default function BlogPostItemHeaderAuthors({
   styles,
 }: {
   styles?: React.CSSProperties;
 }): JSX.Element {
   const {
-    metadata: { authors, formattedDate },
+    metadata: { authors, date },
   } = useBlogPost();
+  const dateTimeFormat = useDateTimeFormat({
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  });
   const authorsCount = authors.length;
   if (authorsCount === 0) {
     return null;
@@ -51,7 +58,7 @@ export default function BlogPostItemHeaderAuthors({
           background: "var(--color-border-strong)",
         }}
       />
-      <span>{formattedDate}</span>
+      <span>{dateTimeFormat.format(new Date(date))}</span>
     </div>
   );
 }

--- a/src/theme/BlogPostItem/components/Info/index.tsx
+++ b/src/theme/BlogPostItem/components/Info/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import clsx from "clsx";
 import { translate } from "@docusaurus/Translate";
 import { usePluralForm } from "@docusaurus/theme-common";
+import { useDateTimeFormat } from "@docusaurus/theme-common/internal";
 import { useBlogPost } from "@docusaurus/plugin-content-blog/client";
 import type { Props } from "@theme/BlogPostItem/Header/Info";
 
@@ -30,7 +31,7 @@ function ReadingTime({ readingTime }: { readingTime: number }) {
   return <>{readingTimePlural(readingTime)}</>;
 }
 
-function Date({
+function DateTime({
   date,
   formattedDate,
 }: {
@@ -52,11 +53,21 @@ export default function BlogPostItemHeaderInfo({
   className,
 }: Props): JSX.Element {
   const { metadata } = useBlogPost();
-  const { date, formattedDate, readingTime } = metadata;
+  const { date, readingTime } = metadata;
+
+  const dateTimeFormat = useDateTimeFormat({
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+
+  const formatDate = (blogDate: string) =>
+    dateTimeFormat.format(new Date(blogDate));
 
   return (
     <div className={clsx(className)}>
-      <Date date={date} formattedDate={formattedDate} />
+      <DateTime date={date} formattedDate={formatDate(date)} />
       {typeof readingTime !== "undefined" && (
         <>
           <Spacer />


### PR DESCRIPTION
After upgrading to Docusaurus v3.10.2, the `formattedDate` field is no longer available in `BlogPostMetadata`. The standard Docusaurus approach uses `useDateTimeFormat()` from `@docusaurus/theme-common/internal` to format the raw `date` string.

<!--Thank you for contributing! -->

<!--In case of an existing issue or discussions, please reference it-->
closes: #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

## Change logs

> Describe your change clearly, including what problem is being solved or what document is being added or updated.

## Contributor's checklist

Here are some reminders before you submit your pull request:

* Make sure that your Pull Request has a clear title and commit message. You can take the [Git commit template](https://github.com/apache/cloudberry/blob/main/.gitmessage) as a reference.
* Learn the [code contribution](https://cloudberry.apache.org/contribute/code) and [doc contribution](https://cloudberry.apache.org/contribute/doc) guides for better collaboration.
* Make sure that your changes deployment preview is successful.
* List your communications in the [GitHub Issues](https://github.com/apache/cloudberry-site/issues) or [Discussions](https://github.com/apache/cloudberry/discussions) (if has or needed).
* Feel free to ask for the [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers) or other people to help review and approve.
